### PR TITLE
Fix libtool/automake issue with libmpirshim.la target

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
-# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +28,7 @@ mpirc_SOURCES = mpirc.c include/mpirshim.h
 mpirc_CFLAGS = $(pmix_CFLAGS)
 mpirc_CPPFLAGS = $(pmix_CPPFLAGS)
 mpirc_LDFLAGS = $(pmix_LDFLAGS) -static
-mpirc_LDADD =  $(pmix_LIBS) $(top_builddir)/src/libmpirshim.la
+mpirc_LDADD =  $(pmix_LIBS) libmpirshim.la
 
 #
 # Testing library


### PR DESCRIPTION
 * Libtool `2.4.2` and Automake `1.13.4` built this fine with the topdir reference
 * Libtool `2.4.6` and Automake `1.16.1` failed to find the libmpirshim.la target

I could not quite figure out exactly why the newer version of the tools
did not like the topdir reference, but both worked fine without it.
