### PR TITLE
Don't wait for launcher termination in attach case

### DIFF
--- a/src/mpirshim.c
+++ b/src/mpirshim.c
@@ -1950,6 +1950,26 @@ int MPIR_Shim_common(mpir_shim_mode_t mpir_mode_, pid_t pid_, int debug_,
             return STATUS_FAIL;
         }
 #endif
+
+        /*
+         * Wait for the launcher to terminate.
+         */
+        debug_print("Waiting for launcher to terminate\n");
+        wait_for_condition(&launch_term_cond);
+        debug_print("Launcher terminated\n");
+
+        /*
+         * Finalize as a PMIx tool.
+         */
+        debug_print("Finalizing as a PMIx tool\n");
+        (void) finalize_as_tool();
+
+        /*
+         * If the launcher returned an exit code, pass it along,
+         * otherwise exit with 0.
+         */
+        debug_print("Exiting with status %d\n", launcher_exit_code);
+        return launcher_exit_code;
     }
     /*
      * If we are connecting to a running PID
@@ -1976,32 +1996,13 @@ int MPIR_Shim_common(mpir_shim_mode_t mpir_mode_, pid_t pid_, int debug_,
         }
 
         /*
-         * Register for the "application has terminated" event.
+         * Finalize as a PMIx tool.
          */
-        if (STATUS_FAIL == register_application_terminate_handler() ) {
-            return STATUS_FAIL;
-        }
+        debug_print("Finalizing as a PMIx tool\n");
+        (void) finalize_as_tool();
+
+        return 0;
     }
-
-    /*
-     * Wait for the launcher to terminate.
-     */
-    debug_print("Waiting for launcher to terminate\n");
-    wait_for_condition(&launch_term_cond);
-    debug_print("Launcher terminated\n");
-
-    /*
-     * Finalize as a PMIx tool.
-     */
-    debug_print("Finalizing as a PMIx tool\n");
-    (void) finalize_as_tool();
-
-    /*
-     * If the launcher returned an exit code, pass it along,
-     * otherwise exit with 0.
-     */
-    debug_print("Exiting with status %d\n", launcher_exit_code);
-    return launcher_exit_code;
 }
 
 


### PR DESCRIPTION
The shim module should not wait for launcher termination in the attach case, so the wait has been removed.

In the attach case, the debugger 
- Launches but does not start the shim module (mpirc), specifying the pid of the launcher process the debugger wants to attach to
- Sets a breakpoint at MPIR_Breakpoint
- Resumes execution of the shim module
- The shim module runs until the launcher's process table is read then calls MPIR_Breakpoint.
- The breakpoint at MPIR_Breakpoint triggers, the debugger gets control and retrieves the MPIR_proctable data
- The debugger sets any breakpoints, etc in the application processes using the MPIR_proctable to locate those processes
- The debugger resumes shim module execution.
- At this point the shim module is no longer needed, so it can just exit.
- The application process is running and continues to do so until one of the breakpoints is hit or the application terminates.

Signed-off-by: David Wootton <dwootton@us.ibm.com>