### PR TITLE
Silence flood of warnings

### DIFF
--- a/src/mpirshim.c
+++ b/src/mpirshim.c
@@ -63,11 +63,11 @@ static void debug_print(char *format, ...);
 /* Funtion entry and exit tracing */
 #define MPIR_SHIM_DEBUG_ENTER(...) { MPIR_SHIM_DEBUG_ENTER_(__VA_ARGS__, ""); }
 #define MPIR_SHIM_DEBUG_ENTER_(format, ...)                             \
-    debug_print(">>> ENTER (%s): " format "\n", __FUNCTION__, ##__VA_ARGS__);
+    debug_print(">>> ENTER (%s): " format "\n", __func__, ##__VA_ARGS__);
 
 #define MPIR_SHIM_DEBUG_EXIT(...) { MPIR_SHIM_DEBUG_EXIT_(__VA_ARGS__, ""); }
 #define MPIR_SHIM_DEBUG_EXIT_(format, ...)                             \
-    debug_print("<<< EXIT  (%s): " format "\n", __FUNCTION__, ##__VA_ARGS__);
+    debug_print("<<< EXIT  (%s): " format "\n", __func__, ##__VA_ARGS__);
 
 
 /**********************************************************************


### PR DESCRIPTION
Use __func__ instead of __FUNCTION__

Signed-off-by: Ralph Castain <rhc@pmix.org>