### PR TITLE
Update README.md to describe use of mpirc executble as a debuger shim layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some PMIx-enabled launchers do not support the MPIR interface, which can be prob
  * Maintain a MPIR Shim written in C (to match the language of OpenPMIx) that provides most of the MPIR interface backed by the PMIx tool interface, and
  * Maintain other example software that can aid tools transitioning from MPIR to the PMIx tool interface.
 
-The MPIR Shim code in this repository is meant to be an example for tools to reference when transitioning to PMIx. As such the software attempts to be structured for readability and reference. It is a fully functional MPIR Shim (see usability notes below) with an rudimentary shared library.
+The MPIR Shim code in this repository is meant to be an example for tools to reference when transitioning to PMIx. As such the software attempts to be structured for readability and reference. It is a fully functional MPIR Shim (see usability notes below) with a rudimentary shared library.
 
 The MPIR Shim does not provide debugging capabilities by itself. It merely provides the symbols and back end functionality to support tools that may choose to use those systems.
 
@@ -89,6 +89,80 @@ mytool -- mpirc -c 1234
 The MPIR Shim will extract the `MPIR_proctable` and idle until the application terminates. You can then use a parallel debugger to connect to the `mpirc` process to read the process table and attach to the remote processes.
 
 Note that Attach Mode assumes a Proxy Mode launch at this time. It may not work with the Non-Proxy mode.
+
+## Using the MPIR Shim Module With Debuggers
+
+The MPIR Shim module can be used with debuggers that are debugging applications in Proxy Mode or Attach Mode. Both modes will be demonstrated using
+gdb and Open MPI below. Assume the MPIR shim module has been built and installed in /u/test/mpir.
+
+### Using the MPIR Shim Module for Debugging in Proxy Mode
+
+Use the debugger to launch the MPIR Shim tool
+
+~~~
+gdb /u/test/mpir/bin/mpirc
+~~~
+
+Set a breakpoint at ``MPIR_Breakpoint``. This breakpoint will be hit once the ``mpirun`` process has built the MPI process table and it is available
+for use by a debugger. 
+
+Once the breakpoint has been set, have gdb run the ``mpirun`` launcher, which starts the application under the control of the MPIR shim module. 
+
+The operands to the gdb ``run`` command are as if the ``mpirun`` command was issued at a shell prompt. Any ``mpirun`` options are allowed as well as any parameters for the application program.
+
+```
+(gdb) b MPIR_Breakpoint
+(gdb) run mpirun -n 2 /u/test/mpi/bin/hello
+```
+
+The launch will run until the MPIR process table in built. When the breakpoint at ``MPIR_Breakpoint`` is hit, you can display MPIR process table information.
+
+```
+Thread 1 "mpirc" hit Breakpoint 1, MPIR_Breakpoint () at mpirshim.c:219
+219         MPIR_SHIM_DEBUG_ENTER("");
+Missing separate debuginfos, use: yum debuginfo-install libevent-2.1.8-5.el8.ppc64le libgcc-8.4.1-1.el8.ppc64le nvidia-driver-cuda-libs-450.142.00-1.el8.ppc64le openssl-libs-1.1.1g-15.el8_3.ppc64le sssd-client-2.4.0-9.el8_4.2.ppc64le zlib-1.2.11-17.el8.ppc64le
+(gdb) p MPIR_proctable_size
+$1 = 2
+(gdb) p MPIR_proctable[0]
+$2 = {
+  host_name = 0x20002400a0f0 "c656f7n05",
+  executable_name = 0x100310e0 "/u/test/mpi/bin/hello",
+  pid = 1501610
+}
+(gdb) p MPIR_proctable[1]
+$3 = {
+  host_name = 0x100310c0 "c656f7n05",
+  executable_name = 0x100da940 "/u/test/mpi/bin/hello",
+  pid = 1501611
+}
+```
+
+Execution of mpirun and the target application continues after you enter the gdb **continue** command.
+
+### Using the MPIR Shim Module for Debugging in Attach Mode
+
+Launch the application program and note the process ID (PID) of the ``mpirun`` process. The application should run 
+long enough that you can start a debugger and attach to the ``mpirun`` process.
+
+```
+c656f7n05:test> mpirun -n 2 hello &
+[1]     1501960
+
+```
+
+Invoke gdb to run the MPIR shim module
+
+```
+gdb /u/test/mpir/bin/mpirc
+```
+
+Set a breakpoint at ``MPIR_Breakpoint`` then run the shim module, specifying the PID of the ``mpirun`` process.
+```
+(gdb) b MPIR_Breakpoint
+(gdb) run mpirun -c 1501960
+```
+
+The launch will run until the MPIR process table in built. When the breakpoint at ``MPIR_Breakpoint`` is hit, you can display MPIR process table information as shown in the description of the ``mpirun`` launch case above.
 
 ## Support
 


### PR DESCRIPTION
Update README.md to describe use of the mpirc MPIR shim module as a shim layer that a debugger can use to access the MPIR process table in a PMIX-based application launcher such as the mpirun command provided by Open MPI.